### PR TITLE
gadget-deadbeef: Proper networkd config with default DNS

### DIFF
--- a/gadget-deadbeef/gadget-deadbeef.network
+++ b/gadget-deadbeef/gadget-deadbeef.network
@@ -4,6 +4,11 @@ Name=usb0
 MACAddress=de:ad:be:ef:00:01
 
 [Network]
+DNS=8.8.8.8
+
+[Address]
 Address=10.0.0.1/24
+
+[Route]
 Gateway=10.0.0.2
 


### PR DESCRIPTION
This patch both cleans up the systemd-networkd config, and also defines `8.8.8.8` as the default DNS entry such that upstream connections work out of the box. Power users will likely change this to their own DNS server, but it's good to have a working default.