### PR TITLE
update checksums for latest toolchain tarballs

### DIFF
--- a/distccd-alarm/PKGBUILD
+++ b/distccd-alarm/PKGBUILD
@@ -26,9 +26,9 @@ source=(http://archlinuxarm.org/builder/xtools/x-tools.tar.xz
 	distccd-armv6h.conf
 	distccd-armv6h.service
         )
-md5sums=('fb4c6977190b3a1d9d39d59f2cb69ed4'
-         '74ab3f88c0d09c67f047532f48116e2f'
-         'b8e2c1056705cf27332022a02fd6b976'
+md5sums=('df3fe198c989fe36e6209e65e4d6ae57'
+         '89905d219fb8dbdce02ed57694e9419c'
+         '577b4ce8f5dbd2c0b3b760701aaa05cd'
          '3706fb6f1c891717861f1101233bebbd'
          '41d29c84a9624653040491226cbf287d'
          '717a4bc07b1c7ad4461603a633e6a008'


### PR DESCRIPTION
MD5 checksums copied from
http://archlinuxarm.org/developers/distcc-cross-compiling
on 2015-10-11.